### PR TITLE
Add chat feature and refactor socket event handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ If you're in Ubuntu:
 
 **Dev**
 
+If you're using `python3` and you get `node-gyp` errors during `npm install` you might need to `apt install python-is-python3` or similar.
+
 ```console
 sudo apt install -y build-essential libgl-dev libxi-dev python
 npm install

--- a/app/index.html
+++ b/app/index.html
@@ -19,7 +19,7 @@
       </a>
     </div>
 
-    <div id="root"></div>
     <div id="ui"></div>
+    <div id="root"></div>
   </body>
 </html>

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -24,6 +24,7 @@ import createApp, {
 } from '-/utils/create-app'
 import constants from '-/constants'
 import { broadcastUpdate } from './net/net'
+import { TYPES } from './net/message-schema'
 
 const create = async ({ scene, renderer, addAnimateCallback }) => {
   logger.debug(addMessage('init: creating camera...'))
@@ -41,7 +42,11 @@ const create = async ({ scene, renderer, addAnimateCallback }) => {
   })
 
   logger.debug(addMessage('init: creating viewer...'))
-  const { physics, animate: animateSystem } = await createViewer(scene, {
+  const {
+    physics,
+    systemBodies,
+    animate: animateSystem,
+  } = await createViewer(scene, {
     system: {
       bodyCount: 256,
       bodyDistance: 0.25,
@@ -50,6 +55,7 @@ const create = async ({ scene, renderer, addAnimateCallback }) => {
       gpuCollisions: true,
     },
   })
+  sceneState.set(['bodyCount'], systemBodies.length)
 
   logger.debug(addMessage('init: creating player ship...'))
   const { ship, animate: animateShip } = await createShip()
@@ -96,8 +102,7 @@ const create = async ({ scene, renderer, addAnimateCallback }) => {
         const player = sceneState.get(['player'])
         const energy = sceneState.get(['player', 'ship', 'energy'])
         if (energy >= 2) {
-          broadcastUpdate(socket, {
-            type: 'cannon',
+          broadcastUpdate(socket, TYPES.CANNON, {
             player,
           })
           shootCannon({

--- a/app/js/net/api-client.js
+++ b/app/js/net/api-client.js
@@ -1,6 +1,6 @@
 import state from '-/state'
 
-const serverConfig = state.get([ 'config', 'server' ])
+const serverConfig = state.get(['config', 'server'])
 const apiUrl = `${serverConfig.host}:${serverConfig.port}`
 
 /**
@@ -14,25 +14,36 @@ export const client = {
     const result = await fetch(`${apiUrl}${route}`, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
       },
-      body: JSON.stringify(data)
+      body: JSON.stringify(data),
     })
     return result
-  }
+  },
 }
 
 /**
  * API Methods
  */
-export const getUser = async username => {
+export const getUser = async (username) => {
   return client.get(`/users/${username}`)
 }
 
-export const createUser = async username => {
+export const createUser = async (username) => {
   return client.post('/users', { username })
 }
 
 export const updateUser = async (username, options) => {
   return client.post(`/users/${username}`, { options })
+}
+
+export const messageUser = async (userId, message) => {
+  return client.post(`/users/${userId}/messages`, {
+    type: 'CHAT',
+    body: {
+      message,
+      to: userId,
+      from: state.get(['scene', 'player', 'username']),
+    },
+  })
 }

--- a/app/js/net/message-schema.js
+++ b/app/js/net/message-schema.js
@@ -1,0 +1,41 @@
+import { define, string, number, object, boolean } from 'superstruct'
+
+export const TYPES = {
+  CANNON: 'CANNON',
+  CHAT: 'CHAT',
+  PLAYER_UPDATE: 'PLAYER_UPDATE',
+}
+
+export const Message = define({
+  type: string(),
+  body: object(),
+  meta: {
+    timestamp: string(),
+  },
+})
+
+export const PlayerUpdate = define({
+  player: object(),
+  position: {
+    x: number(),
+    y: number(),
+    z: number(),
+  },
+  quaternion: {
+    isQuaternion: boolean(),
+    _x: number(),
+    _y: number(),
+    _z: number(),
+    _w: number(),
+  },
+})
+
+export const Cannon = define({
+  player: object(),
+})
+
+export const Chat = define({
+  from: string(),
+  to: string(),
+  message: string(),
+})

--- a/app/js/ui/command-handler.js
+++ b/app/js/ui/command-handler.js
@@ -1,38 +1,36 @@
-import { getUser, createUser, updateUser } from '-/net/api-client'
+import { getUser, createUser, updateUser, messageUser } from '-/net/api-client'
 import sceneState from '-/state/branches/scene'
 import guiState, { toggleHelp } from '-/state/branches/gui'
 
 export const handleCommand = ({ command, clear }) => {
-  const [ cmd, ...args ] = command.split(' ')
+  const [cmd, ...args] = command.split(' ')
   const handlers = {
     '/help': toggleHelp,
 
-    '/whoami': cmd => `Your UUID is ${sceneState.get([ 'player', 'id' ])}`,
+    '/whoami': (cmd) => `Your UUID is ${sceneState.get(['player', 'id'])}`,
 
-    '/players': cmd => {
-      const players = sceneState.get('players').map(p => p.playerId)
+    '/players': (cmd) => {
+      const players = sceneState.get('players')
       if (!players || players.length === 0) {
         return "You're the only player"
       }
-      return `${players.length} other ${
-        players.length === 1 ? 'player' : 'players'
-      } online`
+      return players.map((p) => p.username).join(',')
     },
 
-    '/bodies': cmd => `There area ${sceneState.get('bodyCount')} sim bodies`,
+    '/bodies': (cmd) => `There are ${sceneState.get('bodyCount')} sim bodies`,
 
-    '/clear': cmd => clear(),
+    '/clear': (cmd) => clear(),
 
-    '/ship': cmd => {
-      const [ _, ...args ] = cmd.split(' ')
+    '/ship': (cmd) => {
+      const [_, ...args] = cmd.split(' ')
       for (const arg of args) {
-        const [ key, val ] = arg.split('=')
+        const [key, val] = arg.split('=')
         if (!key || !val) {
           return 'invalid arguments format'
         }
         if (key === 'thrust') {
           sceneState.set(
-            [ 'player', 'ship', 'thrust', 'color' ],
+            ['player', 'ship', 'thrust', 'color'],
             parseInt(val, 16)
           )
           return `set ship thrust color to ${val}`
@@ -41,43 +39,61 @@ export const handleCommand = ({ command, clear }) => {
       }
     },
 
-    '/speed': cmd => {
-      const [ _, speed ] = cmd.split(' ')
-      sceneState.set([ 'player', 'ship', 'movementSpeed' ], parseFloat(speed, 10))
+    '/speed': (cmd) => {
+      const [_, speed] = cmd.split(' ')
+      sceneState.set(['player', 'ship', 'movementSpeed'], parseFloat(speed, 10))
       return `set speed to ${speed}`
     },
 
-    '/shipconfig': cmd => guiState.set([ 'shipConfig', 'isOpen' ], true),
+    '/shipconfig': (cmd) => guiState.set(['shipConfig', 'isOpen'], true),
 
-    '/login': async cmd => {
-      const [ _, username, ...rest ] = cmd.split(' ')
+    '/login': async (cmd) => {
+      const [_, username, ...rest] = cmd.split(' ')
       const userData = await getUser(username)
       if (userData && userData.payload) {
         sceneState.set(
-          [ 'player', 'ship', 'thrust', 'color' ],
+          ['player', 'ship', 'thrust', 'color'],
           userData.payload.options.ship.thrust.color
         )
         sceneState.set(
-          [ 'player', 'ship', 'hull', 'color' ],
+          ['player', 'ship', 'hull', 'color'],
           userData.payload.options.ship.hull.color
         )
-        sceneState.set([ 'player', 'isLoggedIn' ], true)
-        sceneState.set([ 'player', 'username' ], userData.payload.username)
+        sceneState.set(['player', 'isLoggedIn'], true)
+        sceneState.set(['player', 'username'], userData.payload.username)
         return `Logged in as ${username}`
       } else {
         return `Unknown user ${username}`
       }
     },
 
-    '/newuser': async cmd => {
-      const [ _, username, ...rest ] = cmd.split(' ')
+    '/newuser': async (cmd) => {
+      const [_, username, ...rest] = cmd.split(' ')
       const userData = await getUser(username)
       if (userData && userData.payload) {
         return `User ${username} already exists`
       } else {
         const result = await createUser(username)
       }
-    }
+    },
+
+    '/msg': async (cmd) => {
+      const [_, recipient, ...rest] = cmd.split(' ')
+      const players = []
+      if (recipient === 'all') {
+        players.push(
+          ...sceneState
+            .get('players')
+            .filter((p) => p.userId !== sceneState.get('player').userId)
+            .map((p) => p.userId)
+        )
+      } else {
+        players.push(
+          sceneState.get('players').find((p) => p.username === recipient).userId
+        )
+      }
+      players.map((p) => messageUser(p, rest.join(' ')))
+    },
   }
   const handler = handlers[cmd] || (() => `command not found: ${cmd}`)
 

--- a/packages/core/sim/init.js
+++ b/packages/core/sim/init.js
@@ -11,9 +11,9 @@ const defaultConfig = {
     bodyDistance: 1,
     bodySpeed: 0.05,
     deltaT: 0.001,
-    gpuCollisions: true
+    gpuCollisions: true,
   },
-  oimo: false
+  oimo: false,
 }
 
 const init = async (scene, config) => {
@@ -25,7 +25,7 @@ const init = async (scene, config) => {
 
   addLights(scene)
   createGalaxy(scene)
-  createUniverse(scene).map(body => scene.add(body))
+  createUniverse(scene).map((body) => scene.add(body))
 
   const { systemWorker, systemBodies } = await loadSystem({
     scene,
@@ -33,10 +33,10 @@ const init = async (scene, config) => {
     bodyDistance: config.system.bodyDistance,
     bodySpeed: config.system.bodySpeed,
     deltaT: config.system.deltaT,
-    gpuCollisions: config.system.gpuCollisions
+    gpuCollisions: config.system.gpuCollisions,
   })
 
-  systemWorker.onmessage = e => {
+  systemWorker.onmessage = (e) => {
     systemWorker.physics.dt = e.data[0]
     systemWorker.physics.metric = e.data[2]
     systemWorker.physics.collisions = e.data[3]
@@ -56,7 +56,7 @@ const init = async (scene, config) => {
   const systemAnimations = []
   Promise.map(
     systemBodies,
-    async body => {
+    async (body) => {
       const { bodies, animations } = await mkBody(body)
       scene.add(...bodies)
       systemAnimations.push(...animations)
@@ -65,12 +65,12 @@ const init = async (scene, config) => {
     { concurrency: 8 }
   )
 
-  const animate = delta => {
-    systemWorker.postMessage([ 'fetch' ])
-    systemAnimations.map(a => a(delta))
+  const animate = (delta) => {
+    systemWorker.postMessage(['fetch'])
+    systemAnimations.map((a) => a(delta))
   }
 
-  return { systemWorker, animate }
+  return { systemWorker, systemBodies, animate }
 }
 
 export default init

--- a/packages/ui/lib/components/Messages.js
+++ b/packages/ui/lib/components/Messages.js
@@ -1,30 +1,50 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import { css } from '@emotion/css'
 import PropTypes from 'prop-types'
 
 import HudElement from './HudElement'
+import { colors } from './theme'
 
 const style = css`
-  font-size: 0.8em;
+  font-size: 0.7em;
   display: flex;
   align-items: start;
   flex-flow: column;
   justify-content: flex-start;
   width: 100%;
   height: 100%;
-  overflow-y: auto;
-  padding: 1em;
+  > label {
+    height: 2.5em;
+    width: 100%;
+    padding: 0.25em;
+    font-weight: bold;
+    margin-bottom: 0;
+  }
+  > ul {
+    overflow-y: auto;
+    list-style: none;
+    padding: 0;
+    width: 100%;
+    > li {
+      padding: 0 0.25rem;
+      border-top: 1px solid ${colors.primary};
+    }
+  }
 `
 
 const Messages = ({ messages }) => {
+  const lastRef = useRef(null)
+  // Always scroll the dummy last element into view after render
+  useEffect(() => lastRef.current.scrollIntoView())
   return (
     <HudElement>
       <div className={style}>
-        <label style={{ fontWeight: 'bold' }}>System Messages</label>
-        <ul style={{ listStyle: 'none', paddingLeft: '0' }}>
+        <label>Messages</label>
+        <ul>
           {messages.map((m, i) => (
             <li key={`message-${i}`}>{m}</li>
           ))}
+          <li ref={lastRef}></li>
         </ul>
       </div>
     </HudElement>

--- a/server/server/controllers/users.js
+++ b/server/server/controllers/users.js
@@ -1,4 +1,5 @@
 import * as  db from '../db.js'
+import msgpack from 'msgpack-lite'
 
 export const get = async (req, res) => {
   const users = await db.getUsers()
@@ -24,4 +25,16 @@ export const updateUser = async (req, res) => {
     return res.wrap(error)
   }
   res.wrap(user)
+}
+
+export const addUserMessage = async (req, res) => {
+  const { sockets } = req.app.get('socket')
+  const { body } = req.body
+  sockets.map(socket =>
+    socket.emit('event', msgpack.encode({
+      type: 'CHAT',
+      body
+    }))
+  )
+  res.wrap({})
 }

--- a/server/server/server.js
+++ b/server/server/server.js
@@ -2,27 +2,17 @@ import express from 'express'
 import http from 'http'
 import compression from 'compression'
 import cors from 'cors'
-import * as socketio from 'socket.io'
-import { createAdapter } from '@socket.io/redis-adapter'
-import * as redis from 'redis'
-import Promise from 'bluebird'
-import { v4 as uuid } from 'uuid'
-import msgpack from 'msgpack-lite'
 import bodyParser from 'body-parser'
 import bunyan from 'bunyan'
 
 import * as config from './config.js'
 import * as users from './controllers/users.js'
-
-// Promise.promisifyAll(redis.RedisClient.prototype)
-// Promise.promisifyAll(redis.Multi.prototype)
+import { create } from './socket.js'
 
 const main = async (config) => {
-// Promise.promisifyAll(redis.Multi.prototype){
   const app = express()
   app.use(compression())
   app.use(cors())
-  // app.all('*', cors())
 
   const log = bunyan.createLogger({
     name: 'void-api',
@@ -57,54 +47,13 @@ const main = async (config) => {
   app.post('/users', users.createUser)
   app.get('/users/:username', users.getUser)
   app.post('/users/:username', users.updateUser)
+  app.post('/users/:username/messages', users.addUserMessage)
 
   /**
    * Realtime API
    */
-  const io = new socketio.Server(server, {
-    cors: {
-      origin: '*'
-    }
-  })
+  app.set('socket', await create({ server, config, log }))
 
-  const pubClient = redis.createClient({
-    url: config.redis
-  })
-  const subClient = pubClient.duplicate()
-
-  await pubClient.connect()
-  await subClient.connect()
-
-  pubClient.on('error', err => console.error(err))
-  subClient.on('error', err => console.error(err))
-
-  // Store a list of connected sockets to broadcast on
-  // TODO: Remove inactive sockets
-  const sockets = []
-
-  // Broadcast events to all connected sockets
-  subClient.subscribe('events', (message) => {
-    sockets.map(socket =>
-      socket.emit('event', msgpack.encode(JSON.parse(message)))
-    )
-  })
-
-  io.on('connection', socket => {
-    let time = 0
-    const clientId = uuid()
-
-    log.debug({
-      handshake: socket.handshake
-    }, 'Websocket client connected')
-
-    socket.on('events', data => {
-      // console.log('sock:events', data)
-      const message = msgpack.decode(data)
-      // console.log(message)
-      pubClient.publish('events', JSON.stringify(message))
-    })
-    sockets.push(socket)
-  })
 
   server.listen(config.server.port)
   log.info(`Listening on port ${config.server.port}...`)

--- a/server/server/socket.js
+++ b/server/server/socket.js
@@ -1,0 +1,57 @@
+import * as redis from 'redis'
+import * as socketio from 'socket.io'
+import msgpack from 'msgpack-lite'
+import { v4 as uuid } from 'uuid'
+
+export const create = async ({ server, config, log }) => {
+  const io = new socketio.Server(server, {
+    cors: {
+      origin: '*'
+    }
+  })
+
+  const pubClient = redis.createClient({
+    url: config.redis
+  })
+  const subClient = pubClient.duplicate()
+
+  await pubClient.connect()
+  await subClient.connect()
+
+  pubClient.on('error', err => console.error(err))
+  subClient.on('error', err => console.error(err))
+
+  // Store a list of connected sockets to broadcast on
+  // TODO: Remove inactive sockets
+  const sockets = []
+
+  // Broadcast events to all connected sockets
+  subClient.subscribe('events', (message) => {
+    sockets.map(socket =>
+      socket.emit('event', msgpack.encode(JSON.parse(message)))
+    )
+  })
+
+  io.on('connection', socket => {
+    let time = 0
+    const clientId = uuid()
+
+    log.debug({
+      handshake: socket.handshake
+    }, 'Websocket client connected')
+
+    socket.on('events', data => {
+      // console.log('sock:events', data)
+      const message = msgpack.decode(data)
+      // console.log(message)
+      pubClient.publish('events', JSON.stringify(message))
+    })
+    sockets.push(socket)
+  })
+
+  return {
+    sockets,
+    pubClient,
+    subClient
+  }
+}


### PR DESCRIPTION
There are a few different changes here:

- Add socket message schema (app/js/net/message-schema.js)
- Validate socket messages using schema (app/js/net/net.js)
- Add a new `CHAT` message type
- Add a new `/msg` command to the command handler
- Add a new server API route for chat messages

The schema/validation is a first stab at making our socket-based events a little more structured and predictable. I went with the generic schema:
```json
{
  "type": "",
  "body": {},
  "meta": {}
}
```
where `body` will contain the payload and `meta` will have things like timestamps.

For the chat feature, you can test by:
- fire up the API and site
- load 2 instances of the site @ http://localhost:9000
- press `ESC` to open the command window
- type `/msg all <your message>` to broadcast chat messages to all connected players
- or `/msg <username> <your message>` to send a message to a specific player